### PR TITLE
HTMLErrorOut & RoundTable Adjustments

### DIFF
--- a/src/RoundTabler/Configuration.java
+++ b/src/RoundTabler/Configuration.java
@@ -1,17 +1,23 @@
 package RoundTabler;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 
 public class Configuration {
 
     private String type;
+    private String[] validScanTypes = { "all", "nacha", "pci"};
     private String dbType;
+    private String[] validDbTypes = { "mysql", "mysql", "mysql"};
     private String server;
     private String user;
     private String password;
     private String database;
     private String file;
     private String table;
+    private String queryStatement;
 
     public Configuration() {
         this.type = "";
@@ -22,6 +28,7 @@ public class Configuration {
         this.database = "";
         this.file = "";
         this.table = "";
+        this.queryStatement = "";
     }
 
     //All getters and setters for config class
@@ -32,6 +39,12 @@ public class Configuration {
 
     public void setType(String type) {
         this.type = type;
+    }
+
+    public boolean validateScanType(){
+        List<String> types = Arrays.asList(this.validScanTypes);
+
+        return types.contains(this.type.toLowerCase());
     }
 
     public String getDbType() {
@@ -74,6 +87,12 @@ public class Configuration {
         this.database = database;
     }
 
+    public boolean validateDbType(){
+        List<String> types = Arrays.asList(this.validDbTypes);
+
+        return types.contains(this.dbType.toLowerCase());
+    }
+
     public String getFile() {
         return this.file;
     }
@@ -83,11 +102,19 @@ public class Configuration {
     }
 
     public String getTable() {
-        return table;
+        return this.table;
     }
 
     public void setTable(String table) {
         this.table = table;
+    }
+
+    public String getQueryStatement() {
+        return this.queryStatement;
+    }
+
+    public void setQueryStatement(String statement) {
+        this.queryStatement = statement;
     }
 
     //Ensure all required parameters have been filled out except --resultfile since it isn't required
@@ -95,7 +122,7 @@ public class Configuration {
     public boolean allFilled(){
         for(Field f : getClass().getDeclaredFields()) {
             try {
-                if (f.get(this) == "" && !f.getName().equals("file") && !f.getName().equals("table")) {
+                if (f.get(this) == "" && !f.getName().equals("file") && !f.getName().equals("table") && !f.getName().equals("queryStatement")) {
                     return false;
                 }
             } catch (IllegalAccessException e) {

--- a/src/RoundTabler/Configuration.java
+++ b/src/RoundTabler/Configuration.java
@@ -10,7 +10,7 @@ public class Configuration {
     private String type;
     private String[] validScanTypes = { "all", "nacha", "pci"};
     private String dbType;
-    private String[] validDbTypes = { "mysql", "mysql", "mysql"};
+    private String[] validDbTypes = { "mysql", "mariadb", "mysql"};
     private String server;
     private String user;
     private String password;

--- a/src/RoundTabler/HTMLErrorOut.java
+++ b/src/RoundTabler/HTMLErrorOut.java
@@ -105,7 +105,7 @@ public class HTMLErrorOut {
             System.out.println();
             System.out.print("Invalid file path for result, printing error: ");
             System.out.println(error);
-            System.out.println("Please refer to https://github.com/ScottPiersall/RoundTabler/blob/main/README.md for any confusion.");
+            System.out.println("Please refer to https://github.com/ScottPiersall/RoundTabler/blob/main/README.md to help resolve any confusion.");
 
         }
     }

--- a/src/RoundTabler/HTMLErrorOut.java
+++ b/src/RoundTabler/HTMLErrorOut.java
@@ -100,6 +100,10 @@ public class HTMLErrorOut {
 
             htmlWrite.close();
 
+            System.out.println();
+            System.out.println("RoundTabler has encountered an error.");
+            System.out.println("Error information can be found in the error log file that was saved to the specified file path: " + filePath + "errorLog.html");
+
         }catch(IOException e){
 
             System.out.println();

--- a/src/RoundTabler/HTMLErrorOut.java
+++ b/src/RoundTabler/HTMLErrorOut.java
@@ -108,7 +108,7 @@ public class HTMLErrorOut {
             System.out.println();
             System.out.print("Invalid file path for result, printing error: ");
             System.out.println(error);
-            System.out.println("Please refer to https://github.com/ScottPiersall/RoundTabler/blob/main/README.md for any confusion.");
+            System.out.println("Please refer to https://github.com/ScottPiersall/RoundTabler/blob/main/README.md to help resolve any confusion.");
 
         }
     }

--- a/src/RoundTabler/RoundTable.java
+++ b/src/RoundTabler/RoundTable.java
@@ -28,9 +28,11 @@ public class RoundTable {
                 switch (argParts[0]) {
                     case "--type":
                         config.setType(argParts[1]);
+                        if(!config.validateScanType())throw (new InputMismatchException("Invalid scan type of: " + argParts[1] + "."));
                         break;
                     case "--dbtype":
                         config.setDbType(argParts[1]);
+                        if(!config.validateDbType())throw (new InputMismatchException("Invalid database type of: " + argParts[1] + "."));
                         break;
                     case "--server":
                         config.setServer(argParts[1]);
@@ -52,18 +54,48 @@ public class RoundTable {
                         break;
                     default:
                         //If a argument does not match any of the valid argument types then throw exception and stop.
-                        throw(new InputMismatchException("Invalid parameter field of type " + argParts[0].replace("--", "") + ". Please refer to the RoundTabler documentation for valid parameter flags."));
+                        throw(new InputMismatchException("Invalid parameter field of type " + argParts[0].replace("--", "") + "."));
                 }
             }
 
             //Ensures all required parameters needed for RoundTabler to run are filled out. THIS DOES NOT ENSURE --resultfile IS FILLED OUT BECAUSE ITS NOT A REQUIRED PARAMETER
-            if(!config.allFilled())throw(new InputMismatchException("Missing required parameter flag. Please refer to the RoundTabler documentation for all parameter flags required to run."));
+            if(!config.allFilled())throw(new InputMismatchException("Missing required parameter flag."));
+
+
+            switch(config.getDbType()){
+                case "mariaDB":
+                    if(config.getTable().length() != 0){
+                        config.setQueryStatement("SELECT TABLE_NAME, COLUMN_NAME from information_schema.COLUMNS where table_schema=DATABASE() and TABLE_NAME =" + config.getTable() + "and DATA_TYPE in (mediumtext, longtext, text, tinytext, varchar);");
+                    }else{
+                        config.setQueryStatement("SELECT TABLE_NAME, COLUMN_NAME from information_schema.COLUMNS where table_schema=DATABASE() and DATA_TYPE in (mediumtext, longtext, text, tinytext, varchar);");
+                    }
+                    break;
+                case "mysql":
+                    if(config.getTable().length() != 0){
+                        config.setQueryStatement("SELECT table_name, column_name FROM information_schema.tables WHERE table_type='BASE TABLE' AND table_schema = '" + config.getDatabase() + "' AND table_name = '" + config.getTable() + "' AND data_type in (mediumtext, longtext, text, tinytext, varchar);");
+                    }else{
+                        config.setQueryStatement("SELECT table_name, column_name FROM information_schema.tables WHERE table_type='BASE TABLE' AND table_schema = '" + config.getDatabase() + "' AND data_type in (mediumtext, longtext, text, tinytext, varchar);\"");
+                    }
+                    break;
+                case "mongo":
+                    if(config.getTable().length() != 0){
+                        config.setQueryStatement("");
+                    }else{
+                        config.setQueryStatement("");
+                    }
+                    break;
+
+            }
 
 
             //Print Statements signifying next step in RoundTabler process... can be removed just used as a checkpoint to ensure all arg checking is complete.
             System.out.println("ALL REQUIRED PARAMETERS FULFILLED...");
 
             System.out.println("INITIALIZING DATABASE CONNECTION");
+
+
+
+
 
         }catch(InputMismatchException e){
 
@@ -76,6 +108,7 @@ public class RoundTable {
 
                 --server being empty would throw an exception before --resultfile is read. so need to iterate through rest of args in order to print to the requested result file.
             */
+
             for (String elem : args) {
                 if(elem.contains("--resultfile") && elem.split("=").length > 1){
                     filePath = elem.split("=")[1];

--- a/src/RoundTabler/RoundTable.java
+++ b/src/RoundTabler/RoundTable.java
@@ -22,6 +22,23 @@ public class RoundTable {
             for (String elem : args) {
                 String[] argParts = elem.split("=");
 
+                if(elem.contains("--help")){
+                    System.out.println();
+                    System.out.println(
+                            "REQUIRED PARAMETERS:\n" +
+                                    "\t--type= Options include all, pci, nacha\n" +
+                                    "\t--dbtype= Only option currently available is mariadb\n" +
+                                    "\t--server= IP address of database. (Optional) include a colon followed by the port number i.e., 127.0.0.1:3306\n" +
+                                    "\t--user= Your username to log into the database\n" +
+                                    "\t--password= Your password to log into the database\n" +
+                                    "\t--database= The name of the database you want to scan\n" +
+                                    "\nOPTIONAL PARAMETERS:\n" +
+                                    "\t--resultfile= Include a file path to store the results or any error logs\n" +
+                                    "\t--table= Specify one table you would like to have scanned instead of the entire database\n"
+                    );
+                    return;
+                }
+
                 //If any parameters are left empty i.e. "--server=" then throw exception and stop.
                 if(argParts.length == 1)throw(new InputMismatchException("Must provide an argument for parameter flag: " + argParts[0].replace("--", "")));
 
@@ -64,10 +81,12 @@ public class RoundTable {
 
 
             //Print Statements signifying next step in RoundTabler process... can be removed just used as a checkpoint to ensure all arg checking is complete.
+            System.out.println();
             System.out.println("ALL REQUIRED PARAMETERS FULFILLED...");
 
+            System.out.println();
             System.out.println("INITIALIZING DATABASE CONNECTION");
-
+            System.out.println();
 
             if ( config.getDbType().toUpperCase().compareTo("MARIADB") == 0 ) {
                 System.out.println("DEBUG: Attempting Connection");


### PR DESCRIPTION
HTMLErrorOut no longer uses Desktop.getDesktop().browse() since it does not work on Linux. It now specifies where the errorLog.html was saved.

RoundTable now supports a --help command that will list the required and optional parameters. 