### PR TITLE
Add column reading to existing DBReaders

### DIFF
--- a/src/RoundTabler/db/DBReader.java
+++ b/src/RoundTabler/db/DBReader.java
@@ -1,6 +1,8 @@
 package RoundTabler.db;
 
 import java.sql.Connection;
+import java.sql.SQLException;
+
 import RoundTabler.Configuration;
 
 /*
@@ -43,8 +45,16 @@ public abstract class DBReader {
         return this.schemaItems;
     }
 
+    // Close the connection
+    public void closeConnection() {
+        if (this.conn != null)
+            try { this.conn.close(); } catch (SQLException e) { System.out.println(e); }
+    }
+
     // Using a ResultSet or similar data type construct SchemaItems
     // Implemented on a per-database basis, returns true if successful, false otherwise
     abstract public Boolean readSchema();
 
+    // Given a SchemaItem, get its contents as an array of strings
+    abstract public java.util.ArrayList<String> readColumn(SchemaItem item);
 }

--- a/src/RoundTabler/db/MariaReader.java
+++ b/src/RoundTabler/db/MariaReader.java
@@ -3,7 +3,9 @@ package RoundTabler.db;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.PreparedStatement;
+import java.sql.Statement;
 import java.sql.ResultSet;
+import java.util.ArrayList;
 import RoundTabler.Configuration;
 
 /*
@@ -69,4 +71,32 @@ public class MariaReader extends DBReader {
         return true;
     }
 
+    // Return the contents of a column as an ArrayList
+    // TODO: for exceptionally large databases, allow dynamically iterating through results (time + memory usage)
+    public ArrayList<String> readColumn(SchemaItem item) {
+        ArrayList<String> columnData = new ArrayList<String>();
+        ResultSet rs = null;
+
+        try {
+            Statement select = this.conn.createStatement();
+            String queryString = String.format("SELECT %s FROM %s.%s",
+                                                       item.getColumnName(), this.config.getDatabase(), item.getTableName());
+
+            rs = select.executeQuery(queryString);
+
+            // If rs successfully produced results, then we iterate through it
+            if (rs != null) {
+                while (rs.next()) {
+                    // Column data per row
+                    columnData.add(rs.getString(1));
+                }
+            }
+        }
+        catch (SQLException e) {
+            System.out.println(e);
+            return null;
+        }
+
+        return columnData;
+    }
 }

--- a/src/RoundTabler/db/MongoReader.java
+++ b/src/RoundTabler/db/MongoReader.java
@@ -21,4 +21,6 @@ public class MongoReader extends DBReader {
     }
 
     public Boolean readSchema() { return false; }
+
+    public java.util.ArrayList<String> readColumn(SchemaItem item) { return null; }
 }

--- a/src/RoundTabler/db/MySQLReader.java
+++ b/src/RoundTabler/db/MySQLReader.java
@@ -3,7 +3,9 @@ package RoundTabler.db;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.PreparedStatement;
+import java.sql.Statement;
 import java.sql.ResultSet;
+import java.util.ArrayList;
 import RoundTabler.Configuration;
 
 /*
@@ -65,5 +67,34 @@ public class MySQLReader extends DBReader {
         }
 
         return true;
+    }
+
+    // Return the contents of a column as an ArrayList
+    // TODO: for exceptionally large databases, allow dynamically iterating through results (time + memory usage)
+    public ArrayList<String> readColumn(SchemaItem item) {
+        ArrayList<String> columnData = new ArrayList<String>();
+        ResultSet rs = null;
+
+        try {
+            Statement select = this.conn.createStatement();
+            String queryString = String.format("SELECT %s FROM %s.%s",
+                                                       item.getColumnName(), this.config.getDatabase(), item.getTableName());
+
+            rs = select.executeQuery(queryString);
+
+            // If rs successfully produced results, then we iterate through it
+            if (rs != null) {
+                while (rs.next()) {
+                    // Column data per row
+                    columnData.add(rs.getString(1));
+                }
+            }
+        }
+        catch (SQLException e) {
+            System.out.println(e);
+            return null;
+        }
+
+        return columnData;
     }
 }

--- a/src/RoundTabler/db/ReaderMaker.java
+++ b/src/RoundTabler/db/ReaderMaker.java
@@ -38,4 +38,6 @@ public class ReaderMaker extends DBReader {
 
     // Must cover the bases for an abstract class, these are not intended to be called
     public Boolean readSchema() { return false; }
+
+    public java.util.ArrayList<String> readColumn(SchemaItem item) { return null; }
 }


### PR DESCRIPTION
Example usage can be seen below.

The following lines will instantiate a new reader with the configuration and read the schema to gather all the tables and their columns that meet the type requirements. Then, it iterates through the SchemaItems read by the reader and prints the first row result of a query of that column (SELECT column_name FROM table_name)
```java
reader = new ReaderMaker(config).getReader();
reader.readSchema();

for (RoundTabler.db.SchemaItem item : reader.getSchemaItems().SchemaItemResults) {
    System.out.println(item + " - " + item.getColumnType());

    for (String st : reader.readColumn(item)) {
        System.out.println(st);
        break;
    }
}
```