### PR TITLE
added a reset shell script 

### DIFF
--- a/ResetRoundTablerInstance.sh
+++ b/ResetRoundTablerInstance.sh
@@ -1,0 +1,21 @@
+docker stop roundtabler
+echo Stopped pre-existing roundtabler instance
+
+docker rm roundtabler
+echo Removed pre-existing roundtabler instance
+
+docker build --tag roundtabler .
+
+echo Docker instance successfully built. Start container?
+
+docker run -d -t --name roundtabler roundtabler
+
+docker network connect dbNetwork roundtabler
+
+echo:
+echo:
+
+echo Fresh RoundTabler instance ready for testing with updated code.
+
+echo:
+


### PR DESCRIPTION
so the roundtabler docker container can automatically be reset with updated code on MacOS. use this instead of LaunchRoundTablerTestingNetwork if you just need to update the RoundTabler docker contianer and want to keep your mariadb containers. 